### PR TITLE
#3761 - wrap details in details/summary

### DIFF
--- a/css/status.css
+++ b/css/status.css
@@ -39,9 +39,29 @@ ul.status_details img {
     vertical-align: baseline;
 }
 
-ul.status_details {
+.status_expando {
     margin-top: 2em;
     color: black;
+    clear: both;
+}
+
+@media (min-width:40.625rem){
+    .status_expando {
+        width: 80%;
+        margin: 2em auto 0;
+    }
+}
+
+.status_expando summary {
+    text-align: left;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+ul.status_details {
+    margin-top: 0.5em;
     text-align: center;
 }
 
@@ -58,6 +78,7 @@ ul.status_details:after {
 ul.status_details li {
     display: inline-block;
     margin-right: 2em;
+    margin-bottom: 0.25em;
 }
 
 ul.status_details li img {

--- a/index.html
+++ b/index.html
@@ -51,16 +51,19 @@
                     </ul>
                     <div style="display:none" class="contact status_good_state">Everything is running smoothly here, but if you are still experiencing any issues, feel free to consult the Type Network <a href="https://www.typenetwork.com/support">support pages</a> or <a href="mailto:info@typenetwork.com">contact us</a> directly.</div>
                     <div style="display:none" class="contact status_error_state">Uh oh, looks like we’ve got a problem with <span id="status_affected_system">one of our third-party providers</span>. <span id="status_aware">We’re aware of the issue and are working to fix the problem. </span>If you have any further questions, please <a href="mailto:info@typenetwork.com">contact us</a>.</div>
-                    <ul class="status_details">
-                        <li id="status_edgecast_detail"><img src="images/loading.gif"><a href="https://status.verizondigitalmedia.com">Edgecast</a></li>
-                        <li id="status_cloudflare_detail"><img src="images/loading.gif"><a href="https://www.cloudflarestatus.com">Cloudflare</a></li>
-                        <li id="status_sparkpost_detail"><img src="images/loading.gif"><a href="https://status.sparkpost.com">Sparkpost</a></li>
-                        <li id="status_api_detail"><img src="images/loading.gif"><a href="https://rpm.newrelic.com/accounts/1345304/applications/19048925">TN.com API</a></li>
-                        <li id="status_celery_detail"><img src="images/loading.gif"><a href="https://rpm.newrelic.com/accounts/1345304/applications/19048925">Celery</a></li>
-                        <li id="status_psql_detail"><img src="images/loading.gif"><a href="https://rpm.newrelic.com/accounts/1345304/applications/19048925">PSQL</a></li>
-                        <li id="status_redis_detail"><img src="images/loading.gif"><a href="https://rpm.newrelic.com/accounts/1345304/applications/19048925">Redis</a></li>
-                        <li id="status_nginx_detail"><img src="images/loading.gif"><a href="https://rpm.newrelic.com/accounts/1345304/applications/19048925">Nginx</a></li>
-                    </ul>
+                    <details class="status_expando">
+                        <summary>Service Details</summary>
+                        <ul class="status_details">
+                            <li id="status_edgecast_detail"><img src="images/loading.gif"><a href="https://status.verizondigitalmedia.com">Edgecast</a></li>
+                            <li id="status_cloudflare_detail"><img src="images/loading.gif"><a href="https://www.cloudflarestatus.com">Cloudflare</a></li>
+                            <li id="status_sparkpost_detail"><img src="images/loading.gif"><a href="https://status.sparkpost.com">Sparkpost</a></li>
+                            <li id="status_api_detail"><img src="images/loading.gif"><a href="https://rpm.newrelic.com/accounts/1345304/applications/19048925">TN.com API</a></li>
+                            <li id="status_celery_detail"><img src="images/loading.gif"><a href="https://rpm.newrelic.com/accounts/1345304/applications/19048925">Celery</a></li>
+                            <li id="status_psql_detail"><img src="images/loading.gif"><a href="https://rpm.newrelic.com/accounts/1345304/applications/19048925">PSQL</a></li>
+                            <li id="status_redis_detail"><img src="images/loading.gif"><a href="https://rpm.newrelic.com/accounts/1345304/applications/19048925">Redis</a></li>
+                            <li id="status_nginx_detail"><img src="images/loading.gif"><a href="https://rpm.newrelic.com/accounts/1345304/applications/19048925">Nginx</a></li>
+                        </ul>
+                    </details>
                 </div>
                 <footer class="footer-global" id="footer">
                     <ul>


### PR DESCRIPTION
Re close https://github.com/TypeNetwork/typenetwork.com/issues/3761 by tucking the individual status components into a `<details>` tag. Screenshots:

<img width="1422" alt="screen shot 2017-09-27 at 8 25 59 am" src="https://user-images.githubusercontent.com/2061559/30913307-be068dbe-a35d-11e7-9524-0598f2c52a67.png">

<img width="1422" alt="screen shot 2017-09-27 at 8 26 02 am" src="https://user-images.githubusercontent.com/2061559/30913314-bfb16102-a35d-11e7-9e33-8ba5f7018aff.png">
